### PR TITLE
When Launcher and Directory dialogs are widened expand text fields horizontally to fill

### DIFF
--- a/data/directory-editor.ui
+++ b/data/directory-editor.ui
@@ -90,6 +90,7 @@
               <object class="GtkGrid" id="grid1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
                 <property name="row_spacing">6</property>
                 <property name="column_spacing">10</property>
                 <child>
@@ -131,6 +132,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="has_focus">True</property>
+                    <property name="hexpand">True</property>
                     <property name="invisible_char">●</property>
                   </object>
                   <packing>
@@ -144,6 +146,7 @@
                   <object class="GtkEntry" id="comment-entry">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
                     <property name="invisible_char">●</property>
                   </object>
                   <packing>

--- a/data/launcher-editor.ui
+++ b/data/launcher-editor.ui
@@ -90,6 +90,7 @@
               <object class="GtkGrid" id="grid1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
                 <property name="row_spacing">6</property>
                 <property name="column_spacing">10</property>
                 <child>
@@ -148,6 +149,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="has_focus">True</property>
+                    <property name="hexpand">True</property>
                     <property name="invisible_char">●</property>
                   </object>
                   <packing>
@@ -166,6 +168,7 @@
                       <object class="GtkEntry" id="exec-entry">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
                         <property name="invisible_char">●</property>
                       </object>
                       <packing>
@@ -199,6 +202,7 @@
                   <object class="GtkEntry" id="comment-entry">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
                     <property name="invisible_char">●</property>
                   </object>
                   <packing>


### PR DESCRIPTION
When Launcher and Directory dialogs are widened expand text fields horizontally to fill. This gives more room to edit the launcher command line and other text field values.