### PR TITLE
resync cmd line validity on focus gained

### DIFF
--- a/Alacarte/ItemEditor.py
+++ b/Alacarte/ItemEditor.py
@@ -196,6 +196,7 @@ class LauncherEditor(ItemEditor):
 
         self.builder.get_object('name-entry').connect('changed', self.resync_validity)
         self.builder.get_object('exec-entry').connect('changed', self.resync_validity)
+        self.dialog.connect('focus-in-event', self.resync_validity)
 
     def exec_line_is_valid(self, exec_text):
         try:


### PR DESCRIPTION
Often, when the application comlains that the file is not executable, the user has to go to the terminal, set the executable flag, and go back to the application.
Then, he has to somehow trigger the revalidation.
With this PR, the revalidation happens automatically when focus is regained.