### PR TITLE
Fix incorrect reference to attribute

### DIFF
--- a/Alacarte/ItemEditor.py
+++ b/Alacarte/ItemEditor.py
@@ -55,9 +55,8 @@ def try_icon_name(filename):
     return icon_name[:-4]
 
 def get_icon_string(editor, image):
-    filename = editor.icon_file
-    if filename is not None:
-        return try_icon_name(filename)
+    if hasattr(editor, "icon_file"):
+        return try_icon_name(editor.icon_file)
 
     return image.props.icon_name
 


### PR DESCRIPTION
the attribute icon_file can be missing from editor sometimes, see function get_icon_string, experienced this on 22.04 from repository download

details
https://ng572.github.io/blog/2022-08-19-debugging-alacarte-ubuntu-2204/